### PR TITLE
change sequence of legend colors from left to right

### DIFF
--- a/px-simple-bar-chart.html
+++ b/px-simple-bar-chart.html
@@ -184,7 +184,7 @@ A simple bar chart that visualizes series data.
             var dryRun = dryRun || false;
             var dataLength = this.chartData.length;
             var i;
-            for(i=dataLength-1;i>=0;i--) {
+            for( i = 0; i <= dataLength-1; i++) {
                 var series = this.chartData[i];
                 var squareSize = 10;
                 var margin = 5;


### PR DESCRIPTION
The legends appear in reverse order of graph when only one value get plotted for each bar. Example below:
![screen shot 2015-10-23 at 10 53 49 am](https://cloud.githubusercontent.com/assets/7915828/10700727/9a28d330-7974-11e5-9608-03971899475a.png)

Changing the for loop in _drawLegend method to have the legends plotted in line with the bar colors.
![screen shot 2015-10-23 at 10 57 41 am](https://cloud.githubusercontent.com/assets/7915828/10700811/1aebfd30-7975-11e5-962a-f6b7a269bd0c.png)
